### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+**Bodas de Hoy** is a Spanish-language wedding vendor directory and planning platform. This is a **frontend-only** Next.js 12 app (Pages Router) that consumes external GraphQL APIs.
+
+### Node version
+
+Requires **Node 18**. The project uses TypeScript 4.3.5, which is incompatible with newer `@types/node` versions (v20+). Use `nvm use 18` before running any commands.
+
+### Package manager
+
+Both `package-lock.json` and `yarn.lock` exist. Use **npm** with `--legacy-peer-deps` flag due to `react-quill` peer dependency conflict with React 17.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Dev server | `npm run dev` (runs on port 4000) |
+| Lint | `npm run lint` |
+| Build | `npm run build` |
+
+### Known issues
+
+- **`npm run build` fails** due to a pre-existing lockfile issue: `react-day-picker@8.10.1` uses `export { type ... }` syntax unsupported by TypeScript 4.3.5. The dev server (`npm run dev`) works fine since it doesn't enforce full type checking at build time.
+- Category and internal pages may show runtime errors when the external backend API (`api.bodasdehoy.com`) is unreachable or returns unexpected data. The homepage loads correctly regardless.
+
+### External dependencies
+
+All data comes from external services not in this repo:
+- Primary GraphQL API: `https://api.bodasdehoy.com/graphql`
+- Firebase Auth (project `bodasdehoy-1063`)
+- Algolia search (App ID `4YG7QHCVEA`, index `bodasdehoy`)
+
+### Environment variables
+
+- `.env` contains `NEXT_PUBLIC_API_KEY_CONSOLE_GOOGLE` (Google API key, committed)
+- `.env.production` contains production API URLs (committed)
+- For dev, Next.js loads `.env` automatically. The `NEXT_PUBLIC_BASE_URL` is not set in dev mode (only in `.env.production`), so API calls to the backend will fail on internal pages; the homepage still renders.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on this codebase.

### What's included

- Node 18 requirement (TypeScript 4.3.5 compatibility)
- Package manager guidance (`npm` with `--legacy-peer-deps`)
- Key dev commands (`npm run dev`, `npm run lint`, `npm run build`)
- Known build issue documentation (react-day-picker + TS 4.3.5 incompatibility)
- External service dependencies overview
- Environment variable documentation

### Dev environment verification

The development environment was verified working:

- **Lint**: `npm run lint` passes (exit code 0, warnings only)
- **Dev server**: `npm run dev` starts on port 4000 and serves the homepage correctly
- **Build**: `npm run build` has a pre-existing failure due to `react-day-picker@8.10.1` using TS 4.5+ syntax with TS 4.3.5

[bodasdehoy_dev_server_demo.mp4](https://cursor.com/agents/bc-445a4f01-c7c7-4d3c-8f9e-4e39d3868066/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbodasdehoy_dev_server_demo.mp4)

[Homepage fully loaded](https://cursor.com/agents/bc-445a4f01-c7c7-4d3c-8f9e-4e39d3868066/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-445a4f01-c7c7-4d3c-8f9e-4e39d3868066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-445a4f01-c7c7-4d3c-8f9e-4e39d3868066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

