### PR TITLE
Whitelabel: URLs de login del chat y ejemplo env champagne-events

### DIFF
--- a/components/Surface/MultiMenu/ProfileMenu.tsx
+++ b/components/Surface/MultiMenu/ProfileMenu.tsx
@@ -10,6 +10,7 @@ import { RiLoginBoxLine } from "react-icons/ri"
 import { MdLogout } from "react-icons/md"
 import { BsCamera } from "react-icons/bs"
 import Cookies from "js-cookie";
+import { getChatLoginUrl } from "../../../utils/whitelabelUrls";
 
 export const ProfileMenu: FC<any> = ({ isHovered, setHovered, modal, setModal }) => {
   const { user } = AuthContextProvider();
@@ -23,7 +24,12 @@ export const ProfileMenu: FC<any> = ({ isHovered, setHovered, modal, setModal })
       title: "Iniciar sesión",
       onClick: async () => {
         const redirect = encodeURIComponent(window.location.href)
-        window.location.href = `${process.env.NEXT_PUBLIC_CHAT ?? "https://chat.bodasdehoy.com"}/login?redirect=${redirect}`
+        const url = getChatLoginUrl(redirect)
+        if (!url) {
+          console.error("NEXT_PUBLIC_CHAT no está definido.")
+          return
+        }
+        window.location.href = url
       },
       icon: <RiLoginBoxLine />,
       rol: undefined,
@@ -32,7 +38,12 @@ export const ProfileMenu: FC<any> = ({ isHovered, setHovered, modal, setModal })
       title: "Registrarse",
       onClick: async () => {
         const redirect = encodeURIComponent(window.location.href)
-        window.location.href = `${process.env.NEXT_PUBLIC_CHAT ?? "https://chat.bodasdehoy.com"}/login?redirect=${redirect}&q=register`
+        const url = getChatLoginUrl(redirect, "register")
+        if (!url) {
+          console.error("NEXT_PUBLIC_CHAT no está definido.")
+          return
+        }
+        window.location.href = url
       },
       icon: <PiUserPlusLight />,
       rol: undefined,

--- a/components/Surface/Sidebar.tsx
+++ b/components/Surface/Sidebar.tsx
@@ -11,6 +11,7 @@ import { MdLogout } from "react-icons/md"
 import { RiLoginBoxLine } from "react-icons/ri"
 import { BsCamera } from "react-icons/bs"
 import { useAuthentication } from "../../utils/Authentication"
+import { getChatLoginUrl } from "../../utils/whitelabelUrls"
 
 type ItemNav = {
     title: string
@@ -96,7 +97,12 @@ export const Sidebar: FC<propsSidebar> = ({ setShowSidebar, showSidebar }) => {
             icon: <RiLoginBoxLine className="w-6 h-6" />,
             onClick: () => {
                 const redirect = encodeURIComponent(window.location.href)
-                window.location.href = `${process.env.NEXT_PUBLIC_CHAT ?? "https://chat.bodasdehoy.com"}/login?redirect=${redirect}`
+                const url = getChatLoginUrl(redirect)
+                if (!url) {
+                    console.error("NEXT_PUBLIC_CHAT no está definido: no se puede abrir el login del Copilot.")
+                    return
+                }
+                window.location.href = url
             },
             user: "guest"
         },
@@ -105,7 +111,12 @@ export const Sidebar: FC<propsSidebar> = ({ setShowSidebar, showSidebar }) => {
             icon: <PiUserPlusLight className="w-6 h-6" />,
             onClick: () => {
                 const redirect = encodeURIComponent(window.location.href)
-                window.location.href = `${process.env.NEXT_PUBLIC_CHAT ?? "https://chat.bodasdehoy.com"}/login?redirect=${redirect}&q=register`
+                const url = getChatLoginUrl(redirect, "register")
+                if (!url) {
+                    console.error("NEXT_PUBLIC_CHAT no está definido: no se puede abrir el registro del Copilot.")
+                    return
+                }
+                window.location.href = url
             },
             user: "guest"
         },
@@ -156,14 +167,24 @@ export const Sidebar: FC<propsSidebar> = ({ setShowSidebar, showSidebar }) => {
                                     : <div className="text-sm">
                                         <span onClick={() => {
                                             const redirect = encodeURIComponent(window.location.href)
-                                            window.location.href = `${process.env.NEXT_PUBLIC_CHAT ?? "https://chat.bodasdehoy.com"}/login?redirect=${redirect}`
+                                            const url = getChatLoginUrl(redirect)
+                                            if (!url) {
+                                                console.error("NEXT_PUBLIC_CHAT no está definido.")
+                                                return
+                                            }
+                                            window.location.href = url
                                         }}>
                                             Iniciar sesión
                                         </span>
 
                                         <span onClick={() => {
                                             const redirect = encodeURIComponent(window.location.href)
-                                            window.location.href = `${process.env.NEXT_PUBLIC_CHAT ?? "https://chat.bodasdehoy.com"}/login?redirect=${redirect}&q=register`
+                                            const url = getChatLoginUrl(redirect, "register")
+                                            if (!url) {
+                                                console.error("NEXT_PUBLIC_CHAT no está definido.")
+                                                return
+                                            }
+                                            window.location.href = url
                                         }} className="m-1">
                                             / Registrarse
                                         </span>

--- a/env.whitelabel-champagne-events.example
+++ b/env.whitelabel-champagne-events.example
@@ -1,0 +1,12 @@
+# Copiar a .env.production.local (no se sube a git) o definir estas variables en Vercel → Settings → Environment Variables.
+# Dominio whitelabel: champagne-events.com.mx
+
+NEXT_PUBLIC_DOMINIO=.champagne-events.com.mx
+NEXT_PUBLIC_DIRECTORY=https://www.champagne-events.com.mx
+NEXT_PUBLIC_EVENTSAPP=https://app.champagne-events.com.mx
+NEXT_PUBLIC_CHAT=https://chat.champagne-events.com.mx
+NEXT_PUBLIC_MEMORIES=https://memories.champagne-events.com.mx
+NEXT_PUBLIC_SUITE=https://suite.champagne-events.com.mx
+NEXT_PUBLIC_CUSTOMWEB=https://www.champagne-events.com.mx/
+
+# API / CMS / Firebase: sustituir por los valores del tenant (no reutilizar producción de otro dominio sin revisión).

--- a/utils/whitelabelUrls.ts
+++ b/utils/whitelabelUrls.ts
@@ -1,0 +1,20 @@
+/**
+ * Origen del producto Chat (Copilot) para enlaces de login/registro.
+ * Debe coincidir con el subdominio configurado en Vercel para el whitelabel.
+ */
+export function getChatOrigin(): string {
+  const raw = process.env.NEXT_PUBLIC_CHAT
+  if (typeof raw !== "string" || !raw.trim()) {
+    return ""
+  }
+  return raw.replace(/\/+$/, "")
+}
+
+export function getChatLoginUrl(redirect: string, query?: "register"): string | null {
+  const base = getChatOrigin()
+  if (!base) {
+    return null
+  }
+  const q = query === "register" ? "&q=register" : ""
+  return `${base}/login?redirect=${redirect}${q}`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué cambia
- Se elimina el fallback hardcodeado a otro dominio en los enlaces de login/registro del Copilot; si falta `NEXT_PUBLIC_CHAT`, se registra un error en consola en lugar de redirigir mal.
- Se añade `utils/whitelabelUrls.ts` y `env.whitelabel-champagne-events.example` con las variables `NEXT_PUBLIC_*` esperadas para **champagne-events.com.mx**.

## Contexto Vercel (suite y resto)
El fallo `DEPLOYMENT_NOT_FOUND` en los subdominios apunta a dominios no enlazados al deployment en el dashboard de Vercel; el DNS a `cname.vercel-dns.com` ya llega al edge.

## Notas
- En Vercel hay que añadir cada hostname al proyecto correcto y definir las variables de entorno del whitelabel (p. ej. copiando el archivo `.example` a variables del proyecto).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0037a840-39d8-465b-a653-5b6c0293c4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0037a840-39d8-465b-a653-5b6c0293c4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

